### PR TITLE
Fix overloaded import statements.

### DIFF
--- a/src/features/concordanceView/concordanceView.tsx
+++ b/src/features/concordanceView/concordanceView.tsx
@@ -13,7 +13,7 @@ import { useSearchParams } from 'react-router-dom';
 import _ from 'lodash';
 import { usePivotWords } from './usePivotWords';
 import { resetTextSegments } from '../../state/alignment.slice';
-import { useAppDispatch } from '../../app';
+import { useAppDispatch } from '../../app/index';
 
 export type WordFilter = 'aligned' | 'all';
 

--- a/src/features/projects/projectDialog.tsx
+++ b/src/features/projects/projectDialog.tsx
@@ -26,7 +26,7 @@ import { AlignmentSide, Corpus, CorpusContainer, CorpusFileFormat } from '../../
 import { parseTsv, putVersesInCorpus } from '../../workbench/query';
 import BCVWP from '../bcvwp/BCVWPSupport';
 import { AppState } from '../../state/databaseManagement';
-import { useAppDispatch } from '../../app';
+import { useAppDispatch } from '../../app/index';
 import { resetTextSegments } from '../../state/alignment.slice';
 
 


### PR DESCRIPTION
## Problem

When running `yarn start` on my macOS machine, the app fails to start:

<img width="735" alt="image" src="https://github.com/Clear-Bible/clear-aligner/assets/2099731/82f4d8c4-bd40-4f61-977f-7f2e19452140">

## Diagnosis

This seems to be caused by a conflict between `App.tsx` and `app/index.tsx` due to how macOS handles case sensitivity in file names.

## Solution

The small changes in this PR fix the issue for me. I'm open to any solution the development offers. Going forward, it will be helpful if I can use the most recent commit in `main` to demo the app before a build is available.